### PR TITLE
Allow custom _get_sort_key for options

### DIFF
--- a/django_choice_object/tests.py
+++ b/django_choice_object/tests.py
@@ -21,6 +21,27 @@ class TestChoiceOrdered(TestChoice):
     _order_by = "name"
 
 
+class TestCustomOrdering(Choice):
+    LAST = ('last', 'Last', 10)
+    FIRST = ('first', 'First', 1)
+
+    @staticmethod
+    def _get_sort_key(value):
+        return value[2]
+
+
+class TestCustomOrderingInheritance(TestCustomOrdering):
+    MIDDLE = ('middle', 'Middle', 5)
+
+
+class TestSimple(Choice):
+    OTHER = 10
+
+
+class TestMultipleInheritance(TestChoice, TestSimple):
+    pass
+
+
 def get_name_from_choices(value, choices):
     for id, name in choices:
         if id == value:
@@ -51,7 +72,14 @@ class TestChoices(unittest.TestCase):
         self.failUnless(list(TestChoiceOrdered)[-1][0] == TestChoiceOrdered.ZED)
         self.failUnlessEqual(list(TestChoice)[0][0], TestChoice.FIRST)
 
+    def testCustomOrdering(self):
+        self.assertEqual(list(TestCustomOrdering)[0][0], TestCustomOrdering.FIRST)
+        self.assertEqual(list(TestCustomOrdering)[-1][0], TestCustomOrdering.LAST)
+        self.assertEqual(list(TestCustomOrderingInheritance)[0][0], TestCustomOrdering.FIRST)
+        self.assertEqual(list(TestCustomOrderingInheritance)[-1][0], TestCustomOrdering.LAST)
 
+    def testMultipleInheritance(self):
+        self.assertEqual(list(TestMultipleInheritance), list(TestChoice) + list(TestSimple))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rework the way that the _data dictionary is built up to allow custom ordering of options.
- cls._data is now a collections.OrderedDict
- cls._raw stores the original options (with tuple transformation) so that they could be inspected later.
- We collect inherited options from the parents _raw. MRO may not work properly.

---

This is probably a proof of concept at this point. Can you take a look and see what you think? It should have some documentation (and perhaps _get_sort_key could not be underscored?), and it might be worth adding some tests for MRO cases. There's a backwards incompatability in that parent classes now must inherit from Choice to contribute options. This is analogous to the way that Django forms work.
